### PR TITLE
Migrate from coveralls to Code Climate for coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,15 +21,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Python dependencies
-        run: | 
-          pip install -r requirements/dev.txt
-          pip install coveralls
+        run: pip install -r requirements/dev.txt
 
       - name: Run tests
         run: make test
 
       - name: Report Coverage
+        uses: paambaati/codeclimate-action@v3.2.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          coveralls --service=github
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ test:
 		--cov=dicomsorter \
 		--cov-report=html \
 		--cov-report=term \
+		--cov-report=xml \
 		tests
 
 reformat:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # dicomsorter
 Python library for sorting DICOM images
 
-[![Build Status](https://travis-ci.org/dicomsort/dicomsorter.svg?branch=master)](https://travis-ci.org/dicomsort/dicomsorter)
-[![Coverage Status](https://coveralls.io/repos/github/dicomsort/dicomsorter/badge.svg?branch=master)](https://coveralls.io/github/dicomsort/dicomsorter?branch=master)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/57746e94e1700e645e64/test_coverage)](https://codeclimate.com/github/dicomsort/dicomsorter/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/57746e94e1700e645e64/maintainability)](https://codeclimate.com/github/dicomsort/dicomsorter/maintainability)
 
 ### Command Line Interface


### PR DESCRIPTION
We're already using CodeClimate for the maintainability so may as well use it for the test coverage as well