### PR TITLE
Fix compatibility with pydicom 3

### DIFF
--- a/dicomsorter/dicom_utils.py
+++ b/dicomsorter/dicom_utils.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, Generator, List, Optional, Set, Union
 
 import pydicom
 from pydicom import Dataset
-from pydicom.dicomdir import DicomDir
 from pydicom.errors import InvalidDicomError
+from pydicom.uid import MediaStorageDirectoryStorage
 
 from .config import logger
 from .errors import DicomsorterException
@@ -87,7 +87,8 @@ def is_dicom(
             dicom
             and ignore_dicomdir
             and (
-                isinstance(dicom, DicomDir)
+                dicom.file_meta.get("MediaStorageSOPClassUID", default=None)
+                == MediaStorageDirectoryStorage
                 or os.path.basename(filename).lower() == "dicomdir"
             )
         ):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     install_requires=[
         "fasteners>=0.18",
         "pathos>=0.3",
-        "pydicom>=2.3.0",
+        "pydicom>=2.3.0,<4.0",
         "tqdm>=4.64",
     ],
     entry_points={

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -83,7 +83,7 @@ class DicomDirFactory:
             "RecordInUseFlag": 65535,
             "OffsetOfReferencedLowerLevelDirectoryEntity": 0,
             "DirectoryRecordType": "PATIENT",
-            "PatientsName": faker.name(),
+            "PatientName": faker.name(),
             "PatientID": "1234",
         }
 


### PR DESCRIPTION
Hi Jonathan,

thanks a lot for dicomsort(er)! Very helpful tools.

Sending over a small PR fixing issue #15. The pydicom.dicomdir module has been removed in version 3, see https://pydicom.github.io/pydicom/stable/release_notes/index.html

Tests are passing and I've verified it's skipping real-life DICOMDIRs, both with pydicom 2.4.4 and with pydicom 3.0.1.
Also constrained the version to pydicom < 4.0, because new deprecation warnings pop up when running the test suite with pydicom 3.0.1.